### PR TITLE
Pin scipy to <1.12 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ donuts==0.3.5
 astropy>=4.2
 pymysql>=0.9.3
 toml>=0.10.0
+scipy<1.12


### PR DESCRIPTION
It looks like the version of donuts pinned in the requirements.txt doesn't support recent versions of scipy